### PR TITLE
Ci improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
           rustup -V
           cargo fmt -- --version
           cargo clippy -V
+      - name: Build Project with runtime benchmarks
+        run: cargo build --features runtime-benchmarks
       - name: Build
         run: cargo build
       - name: Check Formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Build Project with runtime benchmarks
         run: cargo build --features runtime-benchmarks
       - name: Build
-        run: cargo build
+        run: RUSTFLAGS="-D warnings" cargo build
       - name: Check Formatting
         run: cargo fmt --all -- --check
       - name: Check Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           cargo fmt -- --version
           cargo clippy -V
       - name: Build Project with runtime benchmarks
-        run: cargo build --features runtime-benchmarks
+        run: RUSTFLAGS="-D warnings" cargo build --features runtime-benchmarks
       - name: Build
         run: RUSTFLAGS="-D warnings" cargo build
       - name: Check Formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
           cargo clippy -V
       - name: Build Project with runtime benchmarks
         run: RUSTFLAGS="-D warnings" cargo build --features runtime-benchmarks
+      - name: Test weights generation
+        run: ./target/debug/parachain-polkadex-node benchmark pallet --pallet "*" --extrinsic "*" --steps 2 --repeat 1
       - name: Build
         run: RUSTFLAGS="-D warnings" cargo build
       - name: Check Formatting


### PR DESCRIPTION
Since regular build of the project is not checks code under benchmarks feature - it is required to have this step in the CI so it was added in this PR.
Additionally was added flag in the CI default build to fail CI if warnings are present.