### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: Continuous Integration
 
 on:
-  pull_request: []
+  pull_request:
+    types: [labeled]
   push:
     branches: [develop, main]
 
@@ -11,6 +12,10 @@ env:
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner
+    #  Run the job only if it has proper label or it is triggered by the push to the `develop` or `main` branch.
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ready to review') ||
+      contains(github.event_name, 'push')
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [develop, main]
 
 env:
-  RUNNER_INSTANCE_TYPE: c5d.9xlarge
+  RUNNER_INSTANCE_TYPE: c5d.4xlarge
 
 jobs:
   start-runner:

--- a/.github/workflows/publish-release-binary.yml
+++ b/.github/workflows/publish-release-binary.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 env:
-  RUNNER_INSTANCE_TYPE: c5d.9xlarge
+  RUNNER_INSTANCE_TYPE: c5d.4xlarge
 
 jobs:
   start-runner:


### PR DESCRIPTION
- [X] - Downgrade runner instance to `c5d.4xlarge`
- [X] - Run CI only in a specific conditions (when `ready for review` label is assigned, or currently in `main` or `develop` branch)

Closes #61.