### PR TITLE
Pinned compiler version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,7 @@
 [toolchain]
-channel = "nightly"
+# Pinned version because of multiple compilation errors while use `polkadot-v0.9.43` branch of
+# "Substrate" with newer compiler versions.
+# FIXME: Migrate/bump version of "Substrate" and remove this version pin.
+channel = "nightly-2023-07-27"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Pinned version because of multiple compilation errors while use `polkadot-v0.9.43` branch of `Substrate` with newer compiler versions (tested `polkadot-v1.0.0` but since this is major version release, I assume BC is  not a case so proper migration is required).



:warning: This pinning should be reverted when app will migrate to the new version of the "Substrate".   